### PR TITLE
Update image, fix arm64 build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM golang:1.11-alpine as build-stage
+FROM golang:alpine as build-stage
 
-RUN apk add -u git ca-certificates
+RUN apk add --no-cache -u git ca-certificates gcc musl-dev
 RUN CGO_ENABLED=0 go get github.com/kahing/goofys && \
     go build -o /app/goofys github.com/kahing/goofys
 
 FROM alpine 
 
 # add syslog-ng (syslog required by Goofys)
-RUN apk add -u fuse syslog-ng ca-certificates
+RUN apk add --no-cache -u fuse syslog-ng ca-certificates
 COPY syslog-ng.conf /etc/syslog-ng/syslog-ng.conf
 
 # Copy binary


### PR DESCRIPTION
The build on arm64 was broken, and the base image was out of date. This PR fixes that. I've already published the images to dockerhub for anyone who needs them: https://hub.docker.com/r/brndnmtthws/goofys